### PR TITLE
bz_getSpikes save prompt

### DIFF
--- a/detectors/detectEvents/DetectSlowWaves.m
+++ b/detectors/detectEvents/DetectSlowWaves.m
@@ -685,6 +685,26 @@ function [thresholds,threshfigs] = DetermineThresholds(deltaLFP,gammaLFP,spikes,
         xlabel('t (relative to GA Dip)');ylabel({'GA Dip Amplitude', '(modZ)'})
         colorbar
         xlim([-0.7 0.7])
+
+%% Figure for lab meeting - illustrating threshold procedure
+% xwin = [-0.5 0.5];
+% exampledelta = [7,13,20];
+% figure
+% for ee = 1:length(exampledelta)
+% subplot(6,3,ee+3)
+%     plot(timebins,normrate_DELTA(:,exampledelta(ee)))
+%     hold on
+%     plot(xwin,ratethresh.*[1 1],'r--')
+%     xlim(xwin);ylim([0 1.5])
+%     ylabel('Mean Pop Rate (mean^-^1)');xlabel('t - aligned to delta peak (s)')
+% subplot(6,3,ee)
+%     plot(linspace(timebins(1),timebins(end),length(deltapower_byDELTAmag(:,exampledelta(ee)))),...
+%         deltapower_byDELTAmag(:,exampledelta(ee)),'k','linewidth',2)
+%     title(['Delta Peak: ',num2str(DELTAmagbins(exampledelta(ee)))])
+%     xlim(xwin);ylim([-2 3.5])
+%     ylabel('Delta-Filtered LFP');
+% end
+% NiceSave('ThresholdIllustration',basePath,baseName)
         
 end
 

--- a/detectors/detectEvents/DetectSlowWaves.m
+++ b/detectors/detectEvents/DetectSlowWaves.m
@@ -403,7 +403,7 @@ function usechan = AutoChanSelect(trychans,basePath,NREMInts,spikes)
     baseName = bz_BasenameFromBasepath(basePath);
     figfolder = fullfile(basePath,'DetectionFigures');
     %Exclude badchannels
-    par = LoadParameters(basePath);
+    par = bz_getSessionInfo(basePath);
     if strcmp(trychans,'all') 
         trychans = [par.SpkGrps(:).Channels];
     end

--- a/io/bz_GetSpikes.m
+++ b/io/bz_GetSpikes.m
@@ -16,6 +16,7 @@ function spikes = bz_GetSpikes(varargin)
 %    forceReload     -logical (default=false) to force loading from
 %                     res/clu/spk files
 %    saveMat         -logical (default=false) to save in buzcode format
+%    noPrompts       -logical to supress any user prompts
 %    
 % OUTPUTS
 %
@@ -73,6 +74,7 @@ addParameter(p,'basepath',pwd,@isstr);
 addParameter(p,'getWaveforms',true,@islogical)
 addParameter(p,'forceReload',false,@islogical);
 addParameter(p,'saveMat',false,@islogical);
+addParameter(p,'noPrompts',false,@islogical);
 
 parse(p,varargin{:})
 
@@ -83,6 +85,7 @@ basepath = p.Results.basepath;
 getWaveforms = p.Results.getWaveforms;
 forceReload = p.Results.forceReload;
 saveMat = p.Results.saveMat;
+noPrompts = p.Results.noPrompts;
 
 
 [sessionInfo] = bz_getSessionInfo(basepath);
@@ -103,7 +106,15 @@ if exist([basepath filesep sessionInfo.FileName '.spikes.cellinfo.mat'],'file') 
             warning(['The spikes structure in baseName.spikes.cellinfo.mat ',...
                 'does not fit buzcode standards. Sad.'])
     end
-else % do the below then filter by inputs...
+    
+else % do the below then filter by inputs... (Load from clu/res/fet)
+    
+    if ~noPrompts %Inform the user that they should save a file for later
+        savebutton = questdlg(['Would you like to save your spikes in ',...
+            sessionInfo.FileName,'.spikes.cellinfo.mat?  ',...
+            'This will save significant load time later.']);
+        if strcmp(savebutton,'Yes'); saveMat = true; end
+    end
     
 disp('loading spikes from clu/res/spk files..')
 % find res/clu/fet/spk files here

--- a/io/bz_getSessionInfo.m
+++ b/io/bz_getSessionInfo.m
@@ -7,7 +7,19 @@ end
 d = dir('*sessionInfo*');
 if ~isempty(d) & length(d) == 1
    load(d.name); 
+elseif ~isempty(d) & length(d) > 1
+   warning('multiple sessionInfo files found, running LoadParameters instead..') 
+   sessionInfo = LoadParameters(basePath);
 else
    warning('could not find sessionInfo file, running LoadParameters instead..') 
    sessionInfo = LoadParameters(basePath);
+end
+
+%Here: check sessionInfo using bz_isSessionInfo
+
+%Here: prompt user to add any missing sessionInfo fields and save
+
+%Here: prompt user to save basePath/baseName.sessionInfo.mat if loaded from
+%xml
+
 end

--- a/utilities/bz_isEvents.m
+++ b/utilities/bz_isEvents.m
@@ -21,7 +21,7 @@ if isfield(events,'detectorinfo') && isfield(events,'timestamps') % check that f
      if isstruct(events.detectorinfo) && isvector(events.timestamps) 
          % check that sub fields exist
          if isfield(events.detectorinfo,'detectorname') && isfield(events.detectorinfo,'detectionparms') ...
-                 && isfield(events.detectorinfo,'detectioninterval') && isfield(events.detectorinfo,'detectiondate')
+                 && isfield(events.detectorinfo,'detectionintervals') && isfield(events.detectorinfo,'detectiondate')
             isEvents = true;
          else
              isEvents = false;

--- a/visualization/bz_MultiLFPPlot.m
+++ b/visualization/bz_MultiLFPPlot.m
@@ -55,8 +55,8 @@ end
 winspikes = spikes.spindices(:,1)>=timewin(1) & spikes.spindices(:,1)<=timewin(2);
 %% Calculate and implement spacing between channels
 
-%Space based on median absolute deviation - robust to outliers.
-channelrange = 8.*mad(single(lfp.data(windex,chindex)),1);
+%Space based on median absolute deviation over entire recording - robust to outliers.
+channelrange = 10.*mad(single(lfp.data(:,chindex)),1);
 lfpmidpoints = -cumsum(channelrange);
 lfp.plotdata = (bsxfun(@(X,Y) X+Y,single(lfp.data(windex,chindex)).*scaleLFP,lfpmidpoints));
 


### PR DESCRIPTION
Summary of changes

-bz_GetSpikes now prompts the user to save the spikes.cellinfo.mat, can be disabled with noPrompts option

-bz_getSessionInfo has outline for future field-adding functionality

-bz_isEvents fixed field name

-bz_DetectSlowWaves uses bz_getSessionInfo, and includes hidden figure for threshold detection illustration.

-bz_MultiLFPPlot improved LFP scaling to be the same throughout a recording