### PR TITLE
change fir1 and CircularMean calls

### DIFF
--- a/externalPackages/FMAToolbox/General/CircularDistribution.m
+++ b/externalPackages/FMAToolbox/General/CircularDistribution.m
@@ -121,8 +121,8 @@ for i = 1:nGroups,
 	dist(:,i) = h;
 	% Stats
 	if ~isempty(p)
-% 	  [stats.m(i),stats.r(i)] = CircularMean(p);
-      [stats.m(i),~,~,stats.r(i)] = CircularMean(p);
+ 	  [stats.m(i),stats.r(i)] = CircularMean(p);
+%      [stats.m(i),~,~,stats.r(i)] = CircularMean(p);
 	  stats.k(i) = Concentration(p);
 	  n = sum(groups(:,i));
 	  R = stats.r(i)*n;

--- a/externalPackages/FMAToolbox/General/Filter.m
+++ b/externalPackages/FMAToolbox/General/Filter.m
@@ -115,15 +115,16 @@ switch(type),
 		else
 			[b a] = cheby2(order,ripple,stopband/nyquist,'stop');
 		end
-	case 'fir1',
-		if ~isempty(passband),
-			if passband(1) == 0,
-				[b a] = fir1(order,passband(2)/nyquist,'low');
+	case 'fir1'
+        a = 1;
+		if ~isempty(passband)
+			if passband(1) == 0
+				b = fir1(order,passband(2)/nyquist,'low');
 			else
-				[b a] = fir1(order,passband/nyquist);
+				b = fir1(order,passband/nyquist);
 			end
 		else
-			[b a] = fir1(order,stopband/nyquist,'stop');
+			b = fir1(order,stopband/nyquist,'stop');
 		end
 end
 filtered(:,1) = samples(:,1);

--- a/io/bz_GetSpikes.m
+++ b/io/bz_GetSpikes.m
@@ -116,7 +116,9 @@ disp('loading spikes from clu/res/spk files..')
 % find res/clu/fet/spk files here
 cluFiles = dir([basepath filesep '*.clu*']);  
 resFiles = dir([basepath filesep '*.res*']);
-spkFiles = dir([basepath filesep '*.spk*']);
+if getWaveforms
+    spkFiles = dir([basepath filesep '*.spk*']);
+end
 
 % remove *temp*, *autosave*, and *.clu.str files/directories
 tempFiles = zeros(length(cluFiles),1);
@@ -133,14 +135,16 @@ for i = 1:length(resFiles)
         tempFiles(i) = 1;
     end
 end
-resFiles(tempFiles==1)=[];
-tempFiles = zeros(length(spkFiles),1);
-for i = 1:length(spkFiles)
-    if ~isempty(findstr('temp',spkFiles(i).name)) | ~isempty(findstr('autosave',spkFiles(i).name))
-        tempFiles(i) = 1;
+if getWaveforms
+    resFiles(tempFiles==1)=[];
+    tempFiles = zeros(length(spkFiles),1);
+    for i = 1:length(spkFiles)
+        if ~isempty(findstr('temp',spkFiles(i).name)) | ~isempty(findstr('autosave',spkFiles(i).name))
+            tempFiles(i) = 1;
+        end
     end
+    spkFiles(tempFiles==1)=[];
 end
-spkFiles(tempFiles==1)=[];
 
 if isempty(cluFiles)
     disp('no clu files found...')
@@ -157,8 +161,10 @@ for i = 1:length(cluFiles)
 end
 [shanks ind] = sort(shanks);
 cluFiles = cluFiles(ind); %Bug here if there are any files x.clu.x that are not your desired clus
-resFiles = resFiles(ind); 
-spkFiles = spkFiles(ind);
+resFiles = resFiles(ind);
+if getWaveforms
+    spkFiles = spkFiles(ind);
+end
 
 % check if there are matching #'s of files
 if length(cluFiles) ~= length(resFiles) & length(cluFiles) ~= length(spkFiles)


### PR DESCRIPTION
fix #130 
fix #132 

In Filter, fir1 calls are changed to output only a single argument, which makes the code compatible with Octave.

I ran into a similar problem in CircularDistribution, where it looks like CircularMean should return only 2 output arguments. I'm not sure why there were 4 in the current code, but the 2 output version was commented out just beneath.

PhaseModulation now runs on my machine