### PR TITLE
only compute hilbert once

### DIFF
--- a/analysis/lfp/bz_Filter.m
+++ b/analysis/lfp/bz_Filter.m
@@ -191,8 +191,9 @@ elseif BUZCODE %BUZCODE has samples as a data structure
     filtered.timestamps = samples.timestamps;
     for i = 1:size(samples.data,2),
         filtered.data(:,i) = FiltFiltM(b,a,double(samples.data(:,i)));
-        filtered.amp(:,i) = abs(hilbert(filtered.data(:,i)));
-        filtered.phase(:,i) = angle(hilbert(filtered.data(:,i)));
+	hilb = hilbert(filtered.data(:,i));
+        filtered.amp(:,i) = abs(hilb);
+        filtered.phase(:,i) = angle(hilb);
     end
     filtered.filterparms.passband = passband;
     filtered.filterparms.stopband = stopband;


### PR DESCRIPTION
`hilbert` is a pretty intensive function. Its output wasn't being stored and it was being called twice here. I saved `hilb` as an intermediate variable, which saves us a second `hilbert` call and should speed up the code considerably