### PR TITLE
Fix to anatGrps reading in LoadParameters

### DIFF
--- a/externalPackages/FMAToolbox/IO/LoadParameters.m
+++ b/externalPackages/FMAToolbox/IO/LoadParameters.m
@@ -180,7 +180,7 @@ try
                     parameters.AnatGrps(a).Channels(b) = str2num(p.anatomicalDescription.channelGroups.group{a}.channel{b});
                 end 
             elseif isvector(p.anatomicalDescription.channelGroups.group{a}.channel)
-                parameters.AnatGrps(a).Channels = p.anatomicalDescription.channelGroups.group{a}.channel;
+                parameters.AnatGrps(a).Channels = str2num(p.anatomicalDescription.channelGroups.group{a}.channel);
             else
                 warning('Anatomy Groups seems to have an issue, eh?..') 
             end


### PR DESCRIPTION
Anatomy groups with single channels were read as string, not number... creating problems.  Now fixed
