### PR TITLE
bz_LFPfromDat.m: Fix no-GPU contingency

### DIFF
--- a/io/bz_LFPfromDat.m
+++ b/io/bz_LFPfromDat.m
@@ -62,8 +62,10 @@ lopass = p.Results.lopass;
 import iosr.dsp.*
 
 useGPU = false;
-if gpuDeviceCount>0
-    useGPU = true;
+try
+    if gpuDeviceCount>0
+        useGPU = true;
+    end
 end
 sizeInBytes = 2; %
 


### PR DESCRIPTION
Put a try statement in GPU evaluation statement to allow for non-GPU toolbox case