### PR TITLE
Fix SleepScoreError - was not using notch options for quantification of SW 

### DIFF
--- a/detectors/detectStates/SleepScoreMaster/ClusterStates_GetMetrics.m
+++ b/detectors/detectStates/SleepScoreMaster/ClusterStates_GetMetrics.m
@@ -58,7 +58,17 @@ badtimes = find(totz>5);
 zFFTspec(badtimes,:) = 0;
  
 %% Set Broadband filter weights for Slow Wave
-load('SWweights.mat')
+if exist('SleepScoreLFP','var')
+    if isfield(SleepScoreLFP,'params')
+        if isfield (SleepScoreLFP.params,'SWWeights')
+            SWweights = SleepScoreLFP.params.SWWeights;
+        end
+    end
+end
+if ~exist('SWweights','var')
+    load('SWweights.mat')
+end
+
 assert(isequal(freqlist,SWfreqlist), 'spectrogram freqs.  are not what they should be...')
 broadbandSlowWave = zFFTspec*SWweights';
  


### PR DESCRIPTION
Options are given to allow filtering of certain frequencies, these were being used for channel selection but actually not being used for quantification of spectrum for state scoring.  Fixed now