### PR TITLE
DetectSlowWaves Bug fix...

### DIFF
--- a/detectors/detectEvents/DetectSlowWaves.m
+++ b/detectors/detectEvents/DetectSlowWaves.m
@@ -277,7 +277,7 @@ if ~NOSPIKES
 end
 
 %Merge close DOWNs, take larger of the two peaks
-[DOWNints,mergedidx] = MergeSeparatedInts(DOWNints,minwindur);
+[DOWNints,mergedidx] = MergeSeparatedInts(DOWNints,joinwindur);
 [SWpeakmag,newSWidx] = cellfun(@(X) max(SWpeakmag(X)),mergedidx,'UniformOutput',false);
 newSWidx = cellfun(@(X,Y) X(Y),mergedidx,newSWidx);
 SWpeaks = SWpeaks(newSWidx);


### PR DESCRIPTION
Was merging adjacent slow wave separated by less than minwindur (minimum UP/DOWN duration, default 40ms), rather than joinwindur (default 10ms). Should have little effect on NREM, but was messing up quiet wake UP/DOWN detection 