### PR TITLE
bz_SpktToSpkmat improvements

### DIFF
--- a/analysis/spikes/bz_SpktToSpkmat.m
+++ b/analysis/spikes/bz_SpktToSpkmat.m
@@ -65,7 +65,9 @@ if isempty(overlap)
     overlap = binsize./dt;
 end
 
-
+if mod(overlap,1)~=0
+    error('binsize must be a multiple of dt')
+end
 %% Deal With Input Type Variability
 
 %If spiketimes is in a buzcode structure

--- a/analysis/spikes/bz_SpktToSpkmat.m
+++ b/analysis/spikes/bz_SpktToSpkmat.m
@@ -9,10 +9,12 @@ function [spikemat] = bz_SpktToSpkmat(spikes, varargin)
 %               or [spiketimes, UID] pairs
 %
 %       (options)
-%       'win'       [start stop] time interval to get spike matrix
-%       'binsize'   size of your time bins, in seconds (default: 0.1)
-%       'overlap'   overlap of your time bins (default: 1, no overlap)
-%       'dt'  add (use instead of binsize/overlap)
+%       'dt'        time step (default: 0.1s)
+%       'binsize'   size of your time bins, in seconds (default: =dt)
+%                   NOTE: must be a multiple of dt.
+%       'win'       [start stop] time interval of the recording in which 
+%                   to get spike matrix
+%                   
 %
 %OUTPUT
 %   spikemat
@@ -38,8 +40,9 @@ function [spikemat] = bz_SpktToSpkmat(spikes, varargin)
 %% Options
 p = inputParser;
 addParameter(p,'win',[]);
-addParameter(p,'binsize',0.1);
-addParameter(p,'overlap',1);
+addParameter(p,'binsize',[]);
+addParameter(p,'overlap',[]);
+addParameter(p,'dt',0.1);
 
 
 parse(p,varargin{:})
@@ -47,9 +50,20 @@ parse(p,varargin{:})
 win = p.Results.win;
 binsize = p.Results.binsize;
 overlap = p.Results.overlap;
+dt = p.Results.dt;
 
-dt = binsize./overlap;
+%For legacy use of 'binsize','overlap' input
+if ~isempty(binsize) && ~isempty(overlap)
+    dt = binsize./overlap;
+end
 
+if isempty(binsize)
+    binsize = dt;
+end
+
+if isempty(overlap)
+    overlap = binsize./dt;
+end
 
 
 %% Deal With Input Type Variability
@@ -79,36 +93,6 @@ if numcells == 0
     return
 end
 
-%Spiketimes can be: tsdArray of cells, cell array of cells, cell array of
-%tsdArrays (multiple populations)
-if isa(spiketimes,'tsdArray')
-    numcells = length(spiketimes);
-    for cc = 1:numcells
-        spiketimestemp{cc} = Range(spiketimes{cc},'s');
-    end
-    spiketimes = spiketimestemp;
-    clear spiketimestemp
-elseif isa(spiketimes,'cell') && isa(spiketimes{1},'tsdArray')
-    numpop = length(spiketimes);
-    lastpopnum = 0;
-    for pp = 1:numpop
-        if length(spiketimes{pp})==0
-            spiketimes{pp} = {};
-            popcellind{pp} = [];
-            continue
-        end
-        for cc = 1:length(spiketimes{pp})
-            spiketimestemp{cc} = Range(spiketimes{pp}{cc},'s');
-        end
-        spiketimes{pp} = spiketimestemp;
-        popcellind{pp} = [1:length(spiketimes{pp})]+lastpopnum;
-        lastpopnum = popcellind{pp}(end);
-        clear spiketimestemp
-    end
-    spiketimes = cat(2,spiketimes{:});
-    numcells = length(spiketimes);
-    subpop = 'done';
-end
 
 %Time Window
 if isempty(win) || isequal(win,[0 Inf])
@@ -119,11 +103,11 @@ end
 
 %% The Meat of the function
 
-numts = round((t_end-t_start)/dt);
+numts = ceil((t_end-t_start)/dt);
 
 %Remove spikes after t_end and before t_start (t_offset+t_start)
-spiketimes = cellfun(@(x) x(find(x<t_end)),spiketimes,'UniformOutput',false);
-spiketimes = cellfun(@(x) x(find(x>t_start)),spiketimes,'UniformOutput',false);
+spiketimes = cellfun(@(x) x((x<t_end)),spiketimes,'UniformOutput',false);
+spiketimes = cellfun(@(x) x((x>t_start)),spiketimes,'UniformOutput',false);
 
 
 %Establish Cell Structure... maybe do this with cellfun... or
@@ -144,25 +128,11 @@ spikes_ind_t(find(spikes_ind_t==0)) = 1;
 %Spike Indices - cell
 spikes_ind_c = [cells.index4spikes];
 
-%Recount in overlapping bins for "boxcar" style (needed for MUAhist)
-if exist('overlap','var')
-    spikes_ind_c = repmat(spikes_ind_c,1,overlap);
-    spikes_ind_t_temp = [];
-    for o = 1:overlap
-        spiketimeoffset = o-ceil(overlap/2);
-        spikes_ind_t_temp = [spikes_ind_t_temp spikes_ind_t+spiketimeoffset];
-    end
-    spikes_ind_t = [];
-    spikes_ind_t = spikes_ind_t_temp;
-    %Remove negative t or overhanging spikes
-    spikes_ind_c(find(spikes_ind_t<=0 |spikes_ind_t>=numts)) = [];
-    spikes_ind_t(find(spikes_ind_t<=0 |spikes_ind_t>=numts)) = [];
-end
 
 %Spike Indices - convert to linear index
 spikes_ind = sub2ind(size(spkmat), spikes_ind_t,spikes_ind_c);
 
-%Add Spikes to bins
+%Add Spikes to bins of size dt
 while spikes_ind
     spkmat(spikes_ind) = spkmat(spikes_ind)+1;
     %Remove full bins
@@ -172,7 +142,10 @@ end
 
 t = [0:size(spkmat,1)-1]'*dt+0.5*dt+t_start; %time vector (midpoint)
 
-%spindices = [[cells.spiketimes]',[cells.index4spikes]'];
+% Moving sum to combine spikes into bins of size binsize
+spkmat = movsum(spkmat,overlap);
+t = movmean(t,overlap); %timepoint in the resulting bin is the mean of 
+                        %timepoints from all bins added
 
 spikemat.data = spkmat;
 spikemat.timestamps = t;


### PR DESCRIPTION
-change in input parameters: now recommended to input dt and bin size.
(backwards compatibility with overlap/binsize style input maintained)

-Speed improvement for large bins with small dt (i.e. high overlap)