### PR TITLE
SleepScore Fixes

### DIFF
--- a/detectors/detectStates/SleepScoreMaster/SleepScoreMaster.m
+++ b/detectors/detectStates/SleepScoreMaster/SleepScoreMaster.m
@@ -176,10 +176,11 @@ if length(ThetaChannels) > 1
 end
 
 %Is this still needed?/Depreciated?
-if exist(sessionmetadatapath,'file')%bad channels is an ascii/text file where all lines below the last blank line are assumed to each have a single entry of a number of a bad channel (base 0)
-    load(sessionmetadatapath)
-    rejectChannels = [rejectChannels SessionMetadata.ExtracellEphys.BadChannels];
-elseif isfield(sessionInfo,'badchannels')
+% if exist(sessionmetadatapath,'file')%bad channels is an ascii/text file where all lines below the last blank line are assumed to each have a single entry of a number of a bad channel (base 0)
+%     load(sessionmetadatapath)
+%     rejectChannels = [rejectChannels SessionMetadata.ExtracellEphys.BadChannels];
+% elseif isfield(sessionInfo,'badchannels')
+if isfield(sessionInfo,'badchannels')
     rejectChannels = [rejectChannels sessionInfo.badchannels]; %get badchannels from the .xml
 else
     display('No baseName.SessionMetadata.mat, no badchannels in your xml - so no rejected channels')

--- a/utilities/bz_IDXtoINT.m
+++ b/utilities/bz_IDXtoINT.m
@@ -90,7 +90,7 @@ for ss = 1:numstates
     statetimes = IDX==states(ss);
     %Get indices of state on/offsets
     stateints = [find(diff(statetimes)==1) find(diff(statetimes)==-1)-1];
-    stateints = timestamps(stateints); %Get timestamps of state on/offsets
+    stateints = [timestamps(stateints(:,1)) timestamps(stateints(:,2))]; %Get timestamps of state on/offsets
     
     if isempty(stateints);continue;end 
     


### PR DESCRIPTION
- Removed use of SessionMetadata bad channels... that now funnels into sessionInfo anyway
- Corrected small error in bz_IDXtoINT that results if only one of any class of epoch is found (vertical rather than horizontal [start stop] vector is created - problems ensue).