### PR TITLE
Buzsaki functions for NWB file format

### DIFF
--- a/NWB/bz_GetLFP_NWB.m
+++ b/NWB/bz_GetLFP_NWB.m
@@ -1,0 +1,201 @@
+function [lfp] = bz_GetLFP_NWB(varargin)
+% bz_GetLFP - Get local field potentials.
+
+%  Load local field potentials from NWB file
+
+
+%  USAGE
+%
+%    [lfp] = bz_GetLFP(channels,<options>)
+%
+%  INPUTS
+%
+%    channels(required) -must be first input, numeric  
+%                        list of channels to load (use keyword 'all' for all)
+%                        channID is 0-indexing, a la neuroscope
+%  Name-value paired inputs:
+
+%    'intervals'          -list of time intervals [0 10; 20 30] to read from 
+%                           the LFP file (default is [0 inf])
+%    'downsample'         -factor to downsample the LFP (i.e. 'downsample',5
+%                           will load a 1250Hz .lfp file at 250Hz)
+%
+%  OUTPUT
+%
+%    lfp             struct of lfp data. Can be a single struct or an array
+%                    of structs for different intervals.  lfp(1), lfp(2),
+%                    etc for intervals(1,:), intervals(2,:), etc
+%    .data           [Nt x Nd] matrix of the LFP data
+%    .timestamps     [Nt x 1] vector of timestamps to match LFP data
+%    .interval       [1 x 2] vector of start/stop times of LFP interval
+%    .channels       [Nd X 1] vector of channel ID's
+%    .samplingRate   LFP sampling rate [default = 1250]
+%    .duration       duration, in seconds, of LFP interval
+
+% Copyright (C) 2004-2011 by Michaël Zugaro
+% edited by David Tingley, 2017
+
+
+%% EXAMPLE CALLS
+% lfp_NWB = bz_GetLFP_NWB(5);                                      % Loads the entire signal from channel 5 (#6) from the current folder
+% lfp_NWB = bz_GetLFP_NWB(5, 'nwb_file', nwb_file);                % Loads the entire signal from channel 5 (#6) from the current folder from the specified NWB file
+% lfp_NWB = bz_GetLFP_NWB([5 10], 'nwb_file', nwb_file);           % Loads channels 5 (#6) and 10 (#11)
+% lfp_NWB = bz_GetLFP_NWB(5, 'restrict',[0 120]);                  % Loads channel 5 (#6) between [0, 120] seconds
+% lfp_NWB = bz_GetLFP_NWB(5, 'restrict',[0 120;240.2 265.23]);     % Loads channel 5 (#6) between [0, 120] and [240.2 265.23] seconds
+% lfp_NWB = bz_GetLFP_NWB(5, 'restrict',[0 120], 'downsample', 2); % Loads channel 5 (#6) between [0, 120] seconds and downsamples by a factor of 2
+
+
+% Added support for NWB: Konstantinos Nasiotis 2019
+
+
+%% Parse the inputs!
+
+channelsValidation = @(x) isnumeric(x) || strcmp(x,'all');
+
+% parse args
+p = inputParser;
+addParameter(p,'nwb_file','',@isstr);
+addRequired(p,'channels',channelsValidation)
+addParameter(p,'basename','',@isstr)
+addParameter(p,'intervals',[],@isnumeric)
+addParameter(p,'restrict',[],@isnumeric)
+addParameter(p,'basepath',pwd,@isstr);
+addParameter(p,'downsample',1,@isnumeric);
+addParameter(p,'saveMat',false,@islogical);
+addParameter(p,'forceReload',false,@islogical);
+addParameter(p,'noPrompts',false,@islogical);
+
+parse(p,varargin{:})
+nwb_file         = p.Results.nwb_file;
+channels         = p.Results.channels;
+downsamplefactor = p.Results.downsample;
+basepath         = p.Results.basepath;
+noPrompts        = p.Results.noPrompts;
+
+% doing this so you can use either 'intervals' or 'restrict' as parameters to do the same thing
+intervals = p.Results.intervals;
+restrict = p.Results.restrict;
+if isempty(intervals) && isempty(restrict) % both empty
+    intervals = [0 Inf];
+elseif isempty(intervals) && ~isempty(restrict) % intervals empty, restrict isn't
+    intervals = restrict;
+end
+
+[filepath,name,ext] = fileparts(nwb_file);
+
+
+%% let's check that there is an appropriate NWB file
+if isempty(nwb_file)
+   %disp('No nwb_file given, so we look for a *nwb file in the current directory')
+   d = dir('*nwb');
+   if length(d) > 1 % we assume one .nwb file or this should break
+       error('there is more than one .nwb file in this directory?');
+   elseif length(d) == 0
+       d = dir('*nwb');
+       if isempty(d)
+           error('could not find an nwb file..')
+       end
+   end
+   nwb_file = fullfile(d.folder, d.name);
+   
+   lfp.Filename = d.name;   
+else
+   lfp.Filename = [name ext];   
+end
+
+%% things we can parse from sessionInfo or xml file
+
+sessionInfo = bz_getSessionInfo(basepath, 'noPrompts', noPrompts);
+
+try
+    samplingRate = sessionInfo.lfpSampleRate;
+catch
+    samplingRate = sessionInfo.rates.lfp; % old ugliness we need to get rid of
+end
+samplingRateLFP = samplingRate./downsamplefactor;
+
+if mod(samplingRateLFP,1)~=0
+    error('samplingRate/downsamplefactor must be an integer')
+end
+%% Channel load options
+%Right now this assumes that all means channels 0:nunchannels-1 (neuroscope
+%indexing), we could also add options for this to be select region or spike
+%group from the xml...
+if strcmp(channels,'all')
+    channels = sessionInfo.channels;
+end
+
+%% get the data
+disp('loading LFP file...')
+nIntervals = size(intervals,1);
+
+
+nwb2 = nwbRead(nwb_file);
+
+
+try
+    % Check if the data is in LFP format
+    all_lfp_keys = keys(nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries);
+
+    for iKey = 1:length(all_lfp_keys)
+        if ismember(all_lfp_keys{iKey}, {'lfp','bla bla bla'})   %%%%%%%% ADD MORE HERE, DON'T KNOW WHAT THE STANDARD FORMATS ARE
+            iLFPDataKey = iKey;
+            LFPDataPresent = 1;
+            break % Once you find the data don't look for other keys/trouble
+        else
+            LFPDataPresent = 0;
+        end
+    end
+catch
+    LFPDataPresent = 0;
+end
+
+if ~LFPDataPresent
+    error ('No LFP signals exist in this .nwb file')
+end
+
+
+
+
+
+% returns lfp/bz format
+for i = 1:nIntervals
+    lfp(i).duration = (intervals(i,2)-intervals(i,1));
+    lfp(i).interval = [intervals(i,1) intervals(i,2)];
+
+    % Load data and put into struct
+    % we assume 0-indexing like neuroscope, but bz_LoadBinary uses 1-indexing to
+    % load....
+              
+    if intervals(i,2) == Inf
+        use_this_bracket = sessionInfo.samples_NWB/sessionInfo.lfpSampleRate;
+        data_temp = zeros(length(channels),ceil((use_this_bracket - intervals(i,1))*samplingRateLFP));
+    else
+        use_this_bracket = intervals(i,2);
+        data_temp = zeros(length(channels),floor((intervals(i,2) - intervals(i,1))*samplingRateLFP));
+    end
+    
+    % This is not optimized yet
+    
+    for iChannel = 1:length(channels)
+        disp(['Now concatenating channel: ' num2str(channels(iChannel))])
+        data_temp(iChannel,:) = nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries.get(all_lfp_keys{iLFPDataKey}).data.load([channels(iChannel)+1, intervals(i,1)*samplingRate+1],[1, downsamplefactor],[channels(iChannel)+1, use_this_bracket*samplingRate]);
+    end 
+      
+    lfp(i).data = data_temp'; clear data_temp
+    lfp(i).timestamps = [lfp(i).interval(1):(1/samplingRateLFP):...
+                        (lfp(i).interval(1)+(length(lfp(i).data)-1)/...
+                        samplingRateLFP)]';
+    lfp(i).channels = channels;
+    lfp(i).samplingRate = samplingRateLFP;
+    % check if duration is inf, and reset to actual duration...
+    if lfp(i).interval(2) == inf
+        lfp(i).interval(2) = length(lfp(i).timestamps)/lfp(i).samplingRate;
+        lfp(i).duration = (lfp(i).interval(i,2)-lfp(i).interval(i,1));
+    end
+    
+    if isfield(sessionInfo,'region') && isfield(sessionInfo,'channels')
+        [~,~,regionidx] = intersect(lfp(i).channels,sessionInfo.channels,'stable');
+        lfp(i).region = sessionInfo.region(regionidx); % match region order to channel order..
+    end
+end

--- a/NWB/bz_GetSpikes_NWB.m
+++ b/NWB/bz_GetSpikes_NWB.m
@@ -1,0 +1,245 @@
+function spikes = bz_GetSpikes_NWB(varargin)
+% bz_getSpikes - Get spike timestamps.
+%
+% USAGE
+%
+%    spikes = bz_getSpikes(varargin)
+% 
+% INPUTS
+%
+%    spikeGroups     -vector subset of shank IDs to load (Default: all)
+%    region          -string region ID to load neurons from specific region
+%                     (requires sessionInfo file or units->structures in xml)
+%    UID             -vector subset of UID's to load 
+%    getWaveforms    -logical (default=true) to load mean of raw waveform data
+%    forceReload     -logical (default=false) to force loading from
+%                     res/clu/spk files
+%    saveMat         -logical (default=false) to save in buzcode format
+%    noPrompts       -logical (default=false) to supress any user prompts
+    
+
+% spikes_NWB = bz_GetSpikes_NWB('UID',[2 4 7]);                              % Loads neurons [2, 4 7] from an NWB at the current directory
+% spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'UID',[2 4 7]);        % Loads neurons [2, 4 7] from a specific NWB file
+% spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'spikeGroups', [2,4]); % Loads the neurons from a specific NWB file and spikeGroups [2,4]
+% spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'region', 'unknown');  % Loads the neurons from a specific NWB file and a specified region
+% spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'saveMat',true);       % saves a cellInfo.mat file with all the Neurons
+
+
+% Konstantinos Nasiotis 2019
+
+
+
+%% TODO
+disp(' 1. The template waveform should be filled by: nwb2.units.waveform_mean      The example dataset didnt have any. I added a template')
+disp(' 2. The maxWaveformCh should be added on the example dataset')
+disp(' 3. CluID is probably filled by Kilosort - should be added on the example dataset')
+disp(' 4. getWaveforms is not supported. Not sure nwb holds the spiking waveforms - Havent seen a field - UPDATE, THIS IS NOW SUPPORTED - CHECK nwb2.processing.get("ecephys").nwbdatainterface.get("SpikeEventSeries1")')
+
+
+
+%% Deal With Inputs 
+spikeGroupsValidation = @(x) assert(isnumeric(x) || strcmp(x,'all'),...
+    'spikeGroups must be numeric or "all"');
+
+p = inputParser;
+addParameter(p,'nwb_file','',@isstr);
+addParameter(p,'spikeGroups','all',spikeGroupsValidation);
+addParameter(p,'region','',@isstr); % won't work without sessionInfodata 
+addParameter(p,'UID',[],@isvector);
+addParameter(p,'basepath',pwd,@isstr);
+addParameter(p,'getWaveforms',true,@islogical)
+addParameter(p,'forceReload',false,@islogical);
+addParameter(p,'saveMat',false,@islogical);
+addParameter(p,'noPrompts',false,@islogical);
+
+parse(p,varargin{:})
+
+%% Adding support only for spikeGroups, region and UID for now
+
+nwb_file      = p.Results.nwb_file;
+spikeGroups   = p.Results.spikeGroups;
+region        = p.Results.region;
+UID           = p.Results.UID;
+% basepath     = p.Results.basepath;
+% getWaveforms = p.Results.getWaveforms;
+% forceReload  = p.Results.forceReload;
+saveMat       = p.Results.saveMat;
+% noPrompts    = p.Results.noPrompts;
+
+
+
+
+%% let's check that there is an appropriate NWB file
+if isempty(nwb_file)
+   %disp('No nwb_file given, so we look for a *nwb file in the current directory')
+   d = dir('*nwb');
+   if length(d) > 1 % we assume one .nwb file or this should break
+       error('there is more than one .nwb file in this directory?');
+   elseif length(d) == 0
+       d = dir('*nwb');
+       if isempty(d)
+           error('could not find an nwb file..')
+       end
+   end
+   nwb_file = fullfile(d.folder, d.name);
+end
+
+
+
+nwb2 = nwbRead(nwb_file);
+[the_path, ~, ~] = fileparts(nwb_file);
+
+
+% load([new_path_for_files filesep name '.sessionInfo.mat'])
+sessionInfo = get_SessionInfoFromNWB(nwb2);
+
+
+    nNeurons = length(nwb2.units.id.data.load);
+
+    
+% % % % % % % % % % % % % % % % % % % % % %     
+% CHEK THIS     nwb2.units.electrode_group.data(1).refresh(nwb2)
+% % % % % % % % % % % % % % % % % % % %     
+    
+
+    % Assign neuron to region based on the region that its Shank belongs to
+
+     % Get a single electrode that belongs in that shank
+    electrodes2Shank  = nwb2.general_extracellular_ephys_electrodes.vectordata.get('group_name').data;    
+    electrodes2Region = nwb2.general_extracellular_ephys_electrodes.vectordata.get('location').data;
+    
+    neurons2ShankNames           = cell(1,nNeurons);
+    all_region                   = cell(1,nNeurons);
+    
+    for iNeuron = 1:length(nwb2.units.electrode_group.data)
+        path = nwb2.units.electrode_group.data(iNeuron).path;
+        inds = strfind(path, '/');
+        neurons2ShankNames{iNeuron} = path(inds(end)+1:end);
+        
+        ElectrodesInThatShank = find(strcmp(electrodes2Shank,neurons2ShankNames{iNeuron}));        
+        all_region{iNeuron}   = electrodes2Region{ElectrodesInThatShank(1)};
+        
+    end
+
+    
+    uniqueShanks = unique(neurons2ShankNames,'legacy');
+    shankID_of_selected_Neurons = zeros(1, nNeurons);
+    for iNeuron = 1:nNeurons
+        shankID_of_selected_Neurons(iNeuron) = find(strcmp(uniqueShanks, neurons2ShankNames{iNeuron}));
+    end
+    
+    
+    %% Make the check here of what will be loaded
+    
+    selected_neurons_UID         = false(1,nNeurons);
+    selected_neurons_spikeGroups = false(1,nNeurons);
+    selected_neurons_region      = false(1,nNeurons);
+    
+    % Check which neurons were selected
+    if ~isempty(UID)
+        selected_neurons_UID(UID) = true;
+    end
+    %Check which Shanks were selected
+    if ~isempty(spikeGroups)
+        for iShank = spikeGroups
+            selected_neurons_spikeGroups(find(shankID_of_selected_Neurons==iShank)) = true;
+        end
+    end
+    %Check which regions were selected
+    if ~isempty(region)
+        selected_neurons_region(find(contains(all_region,region))) = true;
+    end
+    
+    UID = find(selected_neurons_UID | selected_neurons_spikeGroups | selected_neurons_region);
+    
+    if isempty(UID)
+        warning(['Warning: The selection made didnt specify any subgroup of neurons. Loading all neurons!'])
+        UID = 1:nNeurons;
+    end
+        
+    
+    %% The first time that this function is loaded, make sure to save a .spikes.cellInfo.mat that contains information from all neurons
+    
+    if saveMat
+        UID_forSaveMAt = 1:nNeurons;
+        temp = get_the_spikes_from_selected_UIDs(UID_forSaveMAt, nwb2, sessionInfo, saveMat, all_region, neurons2ShankNames, the_path); clear temp       
+    end
+        
+    spikes = get_the_spikes_from_selected_UIDs(UID, nwb2, sessionInfo, 0, all_region, neurons2ShankNames, the_path);
+    
+end
+
+
+
+
+function spikes = get_the_spikes_from_selected_UIDs(UID, nwb2, sessionInfo, saveMat, all_region, neurons2ShankNames, the_path)
+        
+    %% Get Spikes
+    spikes = struct;
+    spikes.samplingRate = sessionInfo.rates.wideband;
+    spikes.UID = UID;
+
+    % The template waveform should be filled by: nwb2.units.waveform_mean
+
+    template_Waveform = [21.2963012297339,21.2206998551635,21.5609060407305,...      % This is from a template I used on Kilosort.  
+                         22.8392565561944,28.2241362812803,30.1107342194246,...      % I assign the same on every neuron.
+                         23.9595314702837,24.3822118826549,23.4681225355758,...      % Check if I can get this from nwb
+                         18.0866792366068,11.9973321575690,-2.96486715514583,...
+                         -110.074832790885,-186.628097395696,-240.085142069235,...
+                         -183.947685024562,-143.562805299476,-104.992358564081,...
+                         -3.29132763624548,22.3478476214865,44.7121087898714,...
+                         73.1141706455415,79.3615933259538,82.9182943568817,...
+                         75.0076414359195,70.1691534634109,65.2413184118645,...
+                         51.9698407486342,45.6296345630672,41.3822118826549,...
+                         37.1519713328267,31.5334146317958];
+
+    times       = cell(1,length(UID));
+    rawWaveform = cell(1,length(UID));
+    spindices   = [];
+
+    entry = 0;
+    for iNeuron = UID
+        entry = entry+1;
+        if iNeuron == 1
+            times_temp = nwb2.units.spike_times.data.load(1:sum(nwb2.units.spike_times_index.data.load(iNeuron)));
+        else
+            times_temp = nwb2.units.spike_times.data.load(sum(nwb2.units.spike_times_index.data.load(iNeuron-1))+1:sum(nwb2.units.spike_times_index.data.load(iNeuron)));
+        end
+        times{entry} = times_temp(times_temp~=0)';
+
+        rawWaveform{entry} = template_Waveform;     % The template waveform should be filled by: nwb2.units.waveform_mean     The example dataset didn't have any
+        spindices = [spindices ; times{entry} ones(length(times{entry}),1)*iNeuron];
+    end
+
+    % Spindices have to be sorted according to when each spike occured
+    [~,sortedIndices] = sort(spindices(:,1));
+    spindices = spindices(sortedIndices,:);
+
+    
+    uniqueShanks = unique(neurons2ShankNames,'legacy');
+    shankID_of_selected_Neurons = zeros(1, length(UID));
+    for iNeuron = 1:length(UID)
+        shankID_of_selected_Neurons(iNeuron) = find(strcmp(uniqueShanks, neurons2ShankNames{UID(iNeuron)}));
+    end
+    
+
+    spikes.times        = times;
+    spikes.shankID      = shankID_of_selected_Neurons;
+    spikes.cluID        = ones(1,length(UID))*(-1);      % THESE ARE THE SPIKING TEMPLATES. THEY ARE FILLED FROM KILOSORT. I ADD A NEGATIVE VALUE TO SEE IF IT CAUSES AN ERROR SOMEWHERE
+    spikes.rawWaveform  = rawWaveform;
+    spikes.maxWaveformCh = ones(1,length(UID))*(-1);     % THESE ASSIGN THE MAXIMUM WAVEFORM TO A ACHANNEL. CHECK HOW TO ADD THIS. I ADD A NEGATIVE VALUE TO SEE IF IT CAUSES AN ERROR SOMEWHERE
+    spikes.sessionName  = sessionInfo.FileName;
+    spikes.numcells     = length(UID);
+    spikes.spindices    = spindices;                     % This holds the timing of each spike, sorted, and the neuron it belongs to.
+
+    spikes.region = all_region(UID);
+
+    if saveMat
+        save(fullfile(the_path, [sessionInfo.FileName '.spikes.cellinfo.mat']),'spikes')
+    end
+end
+
+
+
+
+

--- a/NWB/bz_LoadBehavior_NWB.m
+++ b/NWB/bz_LoadBehavior_NWB.m
@@ -1,0 +1,436 @@
+function behavior = bz_LoadBehavior_NWB(varargin)
+
+%% Load Behavior from NWB files following the Buzcode format
+% behavior = bz_LoadBehavior_NWB;                                                                % Checks the current directory for a NWB file. Gives a list with the available behavior fields in the NWB file for the user to choose which one to load
+% behavior = bz_LoadBehavior_NWB('nwb_file', nwb_file);                                          % Checks the specified NWB file. Gives a list with the available behavior fields in the NWB file for the user to choose which one to load
+% behavior = bz_LoadBehavior_NWB('nwb_file', nwb_file, 'EightMazePosition_norm_spatial_series'); % Loads the specific behavior from the specified NWB file
+% behavior = bz_LoadBehavior_NWB('EightMazePosition_norm_spatial_series');                       % Loads the specific behavior from a NWB file in the current directory
+
+
+% The behaviors are loaded straight from the NWB file.
+
+% This code creates a file with the behavior selected the first time it's used.
+% This is done in order to speed up the process of calling it later 
+% (.map takes a long time to compute if the trials are long).
+
+
+% This code is based on the bz_LoadBehavior
+% Konstantinos Nasiotis 2019
+
+
+%% TODO
+
+disp('1. Check if the BAD trials should be included in the computation of the .map field')
+
+
+
+
+%%
+    p = inputParser;
+    addParameter(p,'nwb_file','',@isstr);
+    
+    if size(varargin,2)>2
+        behaviorName = varargin{3};
+        varargin = {varargin{1,1:2}};
+        parse(p,varargin{:})
+        nwb_file = p.Results.nwb_file;
+    elseif size(varargin,2)==1
+        nwb_file   = [];
+        behaviorName = varargin{1};
+    elseif size(varargin,2)==2
+        parse(p,varargin{:})
+        nwb_file     = p.Results.nwb_file;
+        behaviorName = [];
+    elseif size(varargin,2)==0
+        nwb_file     = [];
+        behaviorName = [];
+    end
+
+
+    %% let's check that there is an appropriate NWB file
+    if isempty(nwb_file)
+       %disp('No nwb_file given, so we look for a *nwb file in the current directory')
+       d = dir('*nwb');
+       if length(d) > 1 % we assume one .nwb file or this should break
+           error('there is more than one .nwb file in this directory?');
+       elseif length(d) == 0
+           d = dir('*nwb');
+           if isempty(d)
+               error('could not find an NWB file..')
+           end
+       end
+       nwb_file = fullfile(d.folder, d.name);
+    end
+    
+
+    nwb2 = nwbRead(nwb_file);
+
+    % Check if behavior fields exists in the dataset
+    try
+        allBehaviorKeys = keys(nwb2.processing.get('behavior').nwbdatainterface);
+        
+        behavior_exist_here = ~isempty(allBehaviorKeys);
+        if ~behavior_exist_here
+            disp('No behavior in this .nwb file')
+            return
+            
+        else
+            disp(' ')
+            disp('The following behavior types are present in this dataset')
+            disp('------------------------------------------------')
+            for iBehavior = 1:length(allBehaviorKeys)
+                disp(allBehaviorKeys{iBehavior})
+            end
+            disp(' ')
+        end
+    catch
+        disp('No behavior in this .nwb file')
+        return
+    end
+
+    %% Check if the behavior file has already been computed (it takes some time to fill the .mapping field, especially when the trials are long)
+    %  If the behavior file is already computed, just load the file and return
+    
+    % FIRST CHECK - CHECK IF THE behaviorName REQUESTED EXISTS
+    
+    [the_path, name, ext] = fileparts(nwb_file);
+    
+    if exist(fullfile(the_path, [name '.' behaviorName '.behavior.mat']) , 'file') == 2
+        load(fullfile(the_path, [name '.' behaviorName '.behavior.mat']))
+        disp('Just loading the already computed behavior struct')
+        return
+    else
+        disp('A file with the specified Behavior hasnt already been created. Select the behavior from the list')
+    end
+    
+    %% If a the behavior file doesn't exist, create a new one
+    
+    % Check if a specific behavior was called to be loaded. If not, display a
+    % pop-up list with the available behaviors for selection
+    [iBehavior, ~] = listdlg('PromptString','Which behavior type would you like to load?',...
+                             'ListString',allBehaviorKeys,'SelectionMode','single');
+  
+    % Fill the behavior 
+    behavior = struct; % Initialize
+
+    
+    % Select the key that is within the Behavior selection
+    allBehaviorSUBKeys = keys(nwb2.processing.get('behavior').nwbdatainterface.get(allBehaviorKeys(iBehavior)).spatialseries);    
+    if length(allBehaviorSUBKeys)>1
+        [iSubKeyBehavior, ~] = listdlg('PromptString','Multiple Behavior channel-selections within the selected behavior',...
+                                     'ListString',allBehaviorSUBKeys,'SelectionMode','single');
+    else
+        iSubKeyBehavior = 1;
+    end
+        
+    %% Check if the behavior file has already been computed (it takes some time to fill the .mapping field, especially when the trials are long)
+    %  If the behavior file is already computed, just load the file and return
+
+    % SECOND CHECK - HERE A SUBKEY HAS ALREADY BEEN SET FROM THE SELECTION
+    
+    if exist(fullfile(the_path, [name '.' allBehaviorSUBKeys{iSubKeyBehavior} '.behavior.mat']) , 'file') == 2
+        load(fullfile(the_path, [name '.' allBehaviorSUBKeys{iSubKeyBehavior} '.behavior.mat']))
+        disp('Just loading the already computed behavior struct')
+        return
+    end
+    
+    
+    %% Get the behavior info
+    disp('computing')
+    
+    selected_behavior = nwb2.processing.get('behavior').nwbdatainterface.get(allBehaviorKeys(iBehavior)).spatialseries.get(allBehaviorSUBKeys{iSubKeyBehavior}); % This is for easier reference through the code
+    
+    behavior.samplingRate = 1000 ./ nanmean(diff(selected_behavior.timestamps.load))./1000;
+    behavior.units        = selected_behavior.data_unit;
+
+    Info = allBehaviorKeys{iBehavior};
+%     behavior.description  = selected_behavior.description;
+
+    % Check if timestamps and data have values. If not something weird
+    % is going on
+    if ~isempty(selected_behavior.timestamps)
+        behavior.timestamps = selected_behavior.timestamps.load;
+    else
+        behavior.timestamps     = [];
+        warning(['Behavior: ' Info ' --- Timestamps are empty: weird'])
+    end
+    if ~isempty(selected_behavior.data)
+        
+        % Specifically for position signals, seperate to x and y
+        if ~isempty(strfind(allBehaviorKeys(iBehavior),'position'))
+            data = selected_behavior.data.load;
+            datasubstruct.x = data(1,:)';
+            if size(data,1)>1
+                datasubstruct.y = data(2,:)';
+            end
+            if size(data,1)>2
+                datasubstruct.z = data(3,:)';
+            end
+        else
+            datasubstruct.data = selected_behavior.data.load;
+            
+        end
+        
+        
+    else
+        datasubstruct.data = [];
+        warning(['Behavior: ' Info ' --- Data is empty: weird'])
+    end
+
+
+    % position: .x, .y, and .z
+    % units: millimeters, centimeters, meters[default]
+    % orientation: .x, .y, .z, and .w
+    % rotationType: euler or quaternion[default]
+    % pupil: .x, .y, .diameter
+
+
+%       datasubstruct.reference_frame     = nwb2.acquisition.get(all_raw_keys(allBehaviorKeys(iBehavior))).reference_frame; This seems to be present only on the position_sensor channels
+   
+    % Conside removing these
+    datasubstruct.starting_time_unit  = selected_behavior.starting_time_unit;
+    datasubstruct.timestamps_interval = selected_behavior.timestamps_interval;
+    datasubstruct.comments            = selected_behavior.comments;
+    datasubstruct.control             = selected_behavior.control;
+    datasubstruct.control_description = selected_behavior.control_description;
+    datasubstruct.data_resolution     = selected_behavior.data_resolution;
+    datasubstruct.starting_time       = selected_behavior.starting_time;
+    datasubstruct.help                = selected_behavior.help;
+
+    
+    
+    %% Exclude special characters from the behavior name
+    BehaviorLabel = allBehaviorKeys{iBehavior};    
+    
+    clean_string = regexprep(BehaviorLabel,'[^a-zA-Z0-9_]','');
+    if ~strcmp(clean_string, BehaviorLabel)
+        disp(['The variable name (' BehaviorLabel ') of the Behavior was changed to exclude special characters'])
+        BehaviorLabel = clean_string;
+    end
+    
+    %% If this is a position signal, rename to position to have compatibility with the Buzsaki functions
+    if ~isempty(strfind(allBehaviorKeys(iBehavior),'position'))
+        BehaviorLabel = 'position';
+    end
+    
+    
+    behavior.(BehaviorLabel)    = datasubstruct;
+    
+    % BehaviorInfo
+    behaviorinfo.description       = selected_behavior.description;
+    behaviorinfo.acquisitionsystem = 'Fill Me';
+    behaviorinfo.substructnames    = {BehaviorLabel};
+    behavior.behaviorinfo          = behaviorinfo;
+
+
+    
+    %% Fill the events substructure
+    
+    nTrials          = length(nwb2.intervals_trials.start_time.data.load);
+    uniqueConditions = unique(nwb2.intervals_trials.vectordata.get('condition').data);
+    
+    
+    all_conditions = nwb2.intervals_trials.vectordata.get('condition').data;
+    for iCondition = 1:length(all_conditions)
+        
+        events.trialConditions(iCondition) = find(strcmp(all_conditions{iCondition}, uniqueConditions));%1x221 double     which unique condition each trialCondition belongs to - INDEX
+
+    end
+    events.trialIntervals  = [nwb2.intervals_trials.start_time.data.load nwb2.intervals_trials.stop_time.data.load];       % 221x2 double   start-end of trial in seconds
+    events.conditionType   = unique(nwb2.intervals_trials.vectordata.get('condition').data)';     % 1x10 cell   (central, wheel ...)
+    
+%     nwb2.intervals_trials.id.data.load
+%     nwb2.intervals_trials.colnames
+%     nwb2.intervals_trials.vectordata
+%     nwb2.intervals_trials.vectordata.get('both_visit').data.load
+%     nwb2.intervals_trials.vectordata.get('condition').data
+%     nwb2.intervals_trials.vectordata.get('error_run').data.load
+%     nwb2.intervals_trials.vectordata.get('stim_run').data.load
+%     nwb2.intervals_trials.vectorindex
+    
+    trialTimestampBounds = [nwb2.intervals_trials.start_time.data.load nwb2.intervals_trials.stop_time.data.load];
+    position_timestamps =  selected_behavior.timestamps.load;
+
+    for iTrial = 1:nTrials
+        
+        %% Load only the samples from each trial
+        % Find the indices of the timestamps that are selected
+        
+        [~, iPositionTimestamps] = histc(trialTimestampBounds(iTrial,:), position_timestamps);
+        
+        if iPositionTimestamps(1)~=0 && iPositionTimestamps(2)==0
+            iPositionTimestamps(2) = length(position_timestamps);
+        end
+
+        try
+            position = selected_behavior.data.load([1, iPositionTimestamps(1)], [Inf, iPositionTimestamps(2)]);
+        catch
+            error ('Error loading selected behavior file. Are there datapoints within the trials selection time-period?')
+        end
+        
+        % The boundaries struct will hold the position boundaries of each
+        % TYPE of CONDITION, for all the trials on each condition Type
+        if ~exist('boundaries')
+            if size(position,1)==1
+                boundaries = repmat(struct('x_min',0,'x_max',0),length(uniqueConditions),1);
+            elseif size(position,1)==2
+                boundaries = repmat(struct('x_min',0,'x_max',0,'y_min',0,'y_max',0),length(uniqueConditions),1);
+            elseif size(position,1)==3
+                boundaries = repmat(struct('x_min',0,'x_max',0,'y_min',0,'y_max',0,'z_min',0,'z_max',0),length(uniqueConditions),1);    
+            end
+        end
+
+        
+%         clr = rand(1,3);
+%         plot(position(1,:),position(2,:),'.','color',clr);
+%         drawnow
+                
+        % Get the index of the condition that the trials belong to - this will
+        % be used for defining the spatial boundaries of the condition
+        iConditionOfTrial = find(strcmp(uniqueConditions, nwb2.intervals_trials.vectordata.get('condition').data(iTrial)))';
+
+        
+        trials{1,iTrial}.x = position(1,:)';% 608 x 1
+        if size(position,1)>1
+            trials{1,iTrial}.y = position(2,:)';% 608 x 1
+        end
+        if size(position,1)>2
+            trials{1,iTrial}.z = position(3,:)';% 608 x 1
+        end
+        
+        trials{1,iTrial}.timestamps = position_timestamps(iPositionTimestamps(1):iPositionTimestamps(2));% 608 x 1
+        trials{1,iTrial}.direction  = 'FILL ME'; % 'clockwise' 'counterclockwise'
+        trials{1,iTrial}.type       = nwb2.intervals_trials.vectordata.get('condition').data{iTrial}; % 'central alternation'
+    %     trials{1,iTrial}.orientation    = % 1x1 struct
+    %     trials{1,iTrial}.errorPerMarker = 608 x 1
+
+    end
+    
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    % Map the trials to a 1x201 vector     
+    bins = 200;
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    % normalize positions to template
+    c=1;
+
+    uniqueConditions = unique((events.trialConditions));
+
+    for iCondition = 1:length(uniqueConditions)
+
+        map{iCondition}=[];
+        t_conc=[];
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        % MAYBE SELECT ONLY THE TRIALS THAT WEREN'T BAD HERE
+%         iTrialsInCondition = find(events.trialConditions == uniqueConditions(iCondition) & ~nwb2.intervals_trials.vectordata.get('error_run').data.load');
+        iTrialsInCondition = find(events.trialConditions == uniqueConditions(iCondition));
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        
+        
+
+        for iTrial = 1:length(iTrialsInCondition)
+            selected_trial = trials{iTrialsInCondition(iTrial)}; % I set this for faster typing
+
+            if size(position,1)==1
+                t_conc = [selected_trial.timestamps, selected_trial.x, 20*(selected_trial.timestamps - selected_trial.timestamps(1))]; % Check what this 20 is
+            elseif size(position,1)==2
+                t_conc = [selected_trial.timestamps, selected_trial.x selected_trial.y, 20*(selected_trial.timestamps - selected_trial.timestamps(1))]; % Check what this 20 is
+            elseif size(position,1)==3
+                t_conc = [selected_trial.timestamps, selected_trial.x selected_trial.y selected_trial.z, 20*(selected_trial.timestamps - selected_trial.timestamps(1))]; % Check what this 20 is
+            end
+            
+% % % % % %     templateVector = 1:nBins;
+% % % % % %     target = size(position,2);
+% % % % % %     n_ent = length(templateVector);
+% % % % % %     trials{1,iTrial}.mapping = round(interp1( 1:n_ent, templateVector, linspace(1, n_ent, target) ))';
+
+            disp('the computation below doesnt make the usage of this function practical for on the fly retrieval of the Behavior')
+            if length(t_conc)>=bins
+                while length(t_conc)>bins+1      
+                    
+                    di = pdist(t_conc);
+                    s = squareform(di);
+                    s(find(eye(size(s))))=nan;
+                    [a b] = min(s(:));
+                    [coords blah] = find(s==a);
+                    t_conc(coords(1),:) = (t_conc(coords(1),:)+t_conc(coords(2),:))./2;
+                    t_conc(coords(2),:) = [];
+                end
+                t_conc_all(iTrial,:,:) = t_conc;
+            end
+        end
+        if length(iTrialsInCondition)>0
+            map{iCondition} = squeeze(median(t_conc_all(:,:,:),1));
+        end
+
+        
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        % Assign to the right behavior field
+        if size(position,1)==1 % 1D
+            events.map{iCondition}.x = map{iCondition}(:,2);
+        elseif size(position,1)==2 % 2D   
+            events.map{iCondition}.x = map{iCondition}(:,2);
+            events.map{iCondition}.y = map{iCondition}(:,3);
+        elseif size(position,1)==3 % 3D
+            events.map{iCondition}.x = map{iCondition}(:,2);
+            events.map{iCondition}.y = map{iCondition}(:,3);
+            events.map{iCondition}.z = map{iCondition}(:,4);   
+        end
+        %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+        clear t_conc_all
+
+        disp('finding mapping...')
+        for iTrial =1:length(iTrialsInCondition)  % all trial types (rotations)
+            selected_trial = trials{iTrialsInCondition(iTrial)}; % I set this for faster typing
+            for iPoint = 1:length(selected_trial.timestamps)
+                
+                if size(position,1)==1 % 1D
+                    [a b] = min(nansum(abs([selected_trial.timestamps(iPoint)-map{iCondition}(:,1),...   % Timestamp
+                                            selected_trial.x(iPoint)-map{iCondition}(:,2),...   % X_COORDINATE
+                                           (selected_trial.timestamps(iPoint)-selected_trial.timestamps(1))*50-map{iCondition}(:,1),...  % penalty for time differences
+                                            (40*(iPoint./length(selected_trial.timestamps)*length(map{iCondition}) - (1:length(map{iCondition})))')])'));     % penalty for order differences
+                    
+                elseif size(position,1)==2 % 2D
+                    [a b] = min(nansum(abs([selected_trial.timestamps(iPoint)-map{iCondition}(:,1),...   % Timestamp
+                                            selected_trial.x(iPoint)-map{iCondition}(:,2),...   % X_COORDINATE
+                                            selected_trial.y(iPoint)-map{iCondition}(:,3),...   % Y_COORDINATE 
+                                           (selected_trial.timestamps(iPoint)-selected_trial.timestamps(1))*50-map{iCondition}(:,1),...  % penalty for time differences
+                                            (40*(iPoint./length(selected_trial.timestamps)*length(map{iCondition}) - (1:length(map{iCondition})))')])'));     % penalty for order differences
+                    
+                elseif size(position,1)==3 % 3D
+                    [a b] = min(nansum(abs([selected_trial.timestamps(iPoint)-map{iCondition}(:,1),...   % Timestamp
+                                            selected_trial.x(iPoint)-map{iCondition}(:,2),...   % X_COORDINATE
+                                            selected_trial.y(iPoint)-map{iCondition}(:,3),...   % Y_COORDINATE 
+                                            selected_trial.z(iPoint)-map{iCondition}(:,4),...   % Z_COORDINATE
+                                           (selected_trial.timestamps(iPoint)-selected_trial.timestamps(1))*50-map{iCondition}(:,1),...  % penalty for time differences
+                                            (40*(iPoint./length(selected_trial.timestamps)*length(map{iCondition}) - (1:length(map{iCondition})))')])'));     % penalty for order differences
+                end
+                                    
+                mapping{iCondition}{iTrial}(iPoint,:) = [map{iCondition}(b,1:end) b selected_trial.timestamps(iPoint)];
+            
+            end
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+            %  Assign to the right behavior field
+            trials{iTrialsInCondition(iTrial)}.mapping = mapping{iCondition}{iTrial}(:,end-1);
+            %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+        end
+    end
+    
+    events.trials   = trials;
+    behavior.events = events;
+    
+    %% Check that the behavior structure meets buzcode standards
+    [isBehavior] = bz_isBehavior(behavior);
+    switch isBehavior
+        case false
+            warning('Your behavior structure does not meet buzcode standards. Sad.')
+    end
+    
+    %% Save the behavior files if they are not already saved
+    if exist(fullfile(the_path, [name '.' allBehaviorSUBKeys{iSubKeyBehavior} '.behavior.mat']) ,'file') ~=2
+        save(fullfile(the_path, [name '.' allBehaviorSUBKeys{iSubKeyBehavior} '.behavior.mat']), 'behavior')
+    end
+    
+end

--- a/NWB/bz_LoadEvents_NWB.m
+++ b/NWB/bz_LoadEvents_NWB.m
@@ -1,0 +1,121 @@
+function events = bz_LoadEvents_NWB(varargin)
+
+%% Load events from NWB files following the Buzcode format
+
+% Example calls:
+% events = bz_LoadEvents_NWB;                                                    % Checks the current directory for a NWB file. Gives a list with the available events in the NWB file for the user to choose which one to load
+% events = bz_LoadEvents_NWB('nwb_file', nwb_file);                              % Checks the specified NWB file. Gives a list with the available events in the NWB file for the user to choose which one to load
+% events = bz_LoadEvents_NWB('nwb_file', nwb_file, 'PulseStim_5V_77777ms_LD12'); % Loads the specified event type from the NWB file
+% events = bz_LoadEvents_NWB('PulseStim_5V_77777ms_LD12');                       % Checks the current directory for a NWB file. Loads the specified file
+
+
+% The events are loaded straight from the NWB file. No extra files needed.
+
+% This code is based on the bz_LoadEvents
+% Konstantinos Nasiotis 2019
+
+
+%%
+    p = inputParser;
+    addParameter(p,'nwb_file','',@isstr);
+    
+    if size(varargin,2)>2
+        eventsName = varargin{3};
+        varargin = {varargin{1,1:2}};
+        parse(p,varargin{:})
+        nwb_file = p.Results.nwb_file;
+    elseif size(varargin,2)==1
+        nwb_file   = [];
+        eventsName = varargin{1};
+    elseif size(varargin,2)==2
+        parse(p,varargin{:})
+        nwb_file = p.Results.nwb_file;
+    elseif size(varargin,2)==0
+        nwb_file   = [];
+    end
+
+    %% let's check that there is an appropriate NWB file
+    if isempty(nwb_file)
+       %disp('No nwb_file given, so we look for a *nwb file in the current directory')
+       d = dir('*nwb');
+       if length(d) > 1 % we assume one .nwb file or this should break
+           error('there is more than one .nwb file in this directory?');
+       elseif length(d) == 0
+           d = dir('*nwb');
+           if isempty(d)
+               error('could not find an nwb file..')
+           end
+       end
+       nwb_file = fullfile(d.folder, d.name);
+    end
+    
+    nwb2 = nwbRead(nwb_file);
+
+    % Check if an events field exists in the dataset
+    try
+        events_exist_here = ~isempty(nwb2.stimulus_presentation);
+        if ~events_exist_here
+            disp('No events in this .nwb file')
+            return
+            
+        else
+            all_event_keys = keys(nwb2.stimulus_presentation);
+            disp(' ')
+            disp('The following event types are present in this dataset')
+            disp('------------------------------------------------')
+            for iEvent = 1:length(all_event_keys)
+                disp(all_event_keys{iEvent})
+            end
+            disp(' ')
+        end
+    catch
+        disp('No events in this .nwb file')
+        return
+    end
+    
+    
+    % Check if a specific event was called to be loaded. If not, display a
+    % pop-up list with the available events for selection
+    if ~exist('eventsName','var')
+        [iEvent, ~] = listdlg('PromptString','Which event type would you like to load?',...
+                                 'ListString',all_event_keys,'SelectionMode','single');
+    else
+        if sum(ismember(all_event_keys, eventsName))>0
+            iEvent = find(ismember(all_event_keys, eventsName));
+        end
+    end
+    
+    events = struct;
+
+    events.timestamps                      = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).timestamps.load;% neuroscope compatible matrix with 1-2 columns - [starts stops] (in seconds)  
+    events.detectorinfo.detectorname       = 'N/A';% substructure with information about the detection method (fields below)
+    events.detectorinfo.detectionparms     = 'N/A';% parameters used for detection  
+    events.detectorinfo.detectiondate      = 'N/A';% date of detection
+    events.detectorinfo.detectionintervals = 'N/A';% [start stop] pairs of intervals used for detection (optional)
+%         events.detectorinfo.detectionchannel   = ;% channel used for detection (optional)  
+
+%         % Optional
+%         events.amplitudes  = 1;% [Nx1 matrix]
+%         events.frequencies = 1;% [Nx1 matrix]
+%         events.durations   = 1;% [Nx1 matrix]
+
+
+    % I add here the rest of the parameters that are saved on the nwb file
+    events.starting_time_unit  = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).starting_time_unit;
+    events.timestamps_interval = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).timestamps_interval;
+    events.timestamps_unit     = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).timestamps_unit;
+    events.comments            = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).comments;
+    events.control             = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).control;
+    events.control_description = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).control_description;
+    events.data                = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).data;
+    events.data_conversion     = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).data_conversion;
+    events.data_resolution     = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).data_resolution;
+    events.data_unit           = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).data_unit;
+    events.description         = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).description;
+    events.starting_time       = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).starting_time;
+    events.starting_time_rate  = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).starting_time_rate;
+    events.help                = nwb2.stimulus_presentation.get(all_event_keys{iEvent}).help;
+    
+    
+end
+

--- a/NWB/get_SessionInfoFromNWB.m
+++ b/NWB/get_SessionInfoFromNWB.m
@@ -1,0 +1,181 @@
+function sessionInfo = get_SessionInfoFromNWB(nwb2)
+
+%% get_SessionInfoFromNWB populates a variable similar to sessionInfo standards.
+% Not all fields are filled (most are commented out). 
+% Only those that were needed so far in the functions tested. 
+% More can be filled on demand.
+
+
+
+
+%% Get the type of the recording (its key will be used to get info from the nwb file)
+% There will be 2 logical values:
+% RawDataPresent
+% LFPDataPresent
+
+% The keys are not finalized yet from the NWB format so some updating will
+% be needed.
+
+
+%% Populate fields
+
+
+% First check if there are raw data present
+
+try
+    all_raw_keys = keys(nwb2.acquisition);
+
+    for iKey = 1:length(all_raw_keys)
+        if ismember(all_raw_keys{iKey}, {'ECoG','bla bla bla'})   %%%%%%%% ADD MORE HERE, DON'T KNOW WHAT THE STANDARD FORMATS ARE
+            iRawDataKey = iKey;
+            RawDataPresent = 1;
+        else
+            RawDataPresent = 0;
+        end
+    end
+    % nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries.get('all_lfp').data
+catch
+    RawDataPresent = 0;
+end
+
+
+
+
+try
+    % Check if the data is in LFP format
+    all_lfp_keys = keys(nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries);
+
+    for iKey = 1:length(all_lfp_keys)
+        if ismember(all_lfp_keys{iKey}, {'lfp','bla bla bla'})   %%%%%%%% ADD MORE HERE, DON'T KNOW WHAT THE STANDARD FORMATS ARE
+            iLFPDataKey = iKey;
+            LFPDataPresent = 1;
+            break % Once you find the data don't look for other keys/trouble
+        else
+            LFPDataPresent = 0;
+        end
+    end
+catch
+    LFPDataPresent = 0;
+end
+
+
+if ~RawDataPresent && ~LFPDataPresent
+    error 'There is no data in this .nwb - Maybe check if the Keys are labeled correctly'
+end
+
+
+
+%% Creare SessionInfo
+sessionInfo = struct;
+
+if RawDataPresent
+    sessionInfo.nChannels      = nwb2.acquisition.get(all_raw_keys{iRawDataKey}).data.dims(2);
+    sessionInfo.samples_NWB    = nwb2.acquisition.get(all_raw_keys{iRawDataKey}).data.dims(1);
+    sessionInfo.rates.wideband = nwb2.acquisition.get(all_raw_keys{iRawDataKey}).starting_time_rate;
+    sessionInfo.rates.lfp      = 1250;    %1250 -  DEFAULT - CHECK THIS
+    sessionInfo.lfpSampleRate  = 1250;    %1250 -  DEFAULT - CHECK THIS % tH lfpSampleRate bypasses 
+
+elseif LFPDataPresent
+    sessionInfo.nChannels      = nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries.get(all_lfp_keys{iLFPDataKey}).data.dims(2);
+    sessionInfo.samples_NWB    = nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries.get(all_lfp_keys{iLFPDataKey}).data.dims(1);
+    sessionInfo.rates.wideband = nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries.get(all_lfp_keys{iLFPDataKey}).starting_time_rate;
+    sessionInfo.rates.lfp      = nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries.get(all_lfp_keys{iLFPDataKey}).starting_time_rate;    %I assign the LFP sampling rate that was already used. Not sure yet if a different value than 1250 Hz will cause problems
+    sessionInfo.lfpSampleRate  = nwb2.processing.get('ecephys').nwbdatainterface.get('LFP').electricalseries.get(all_lfp_keys{iLFPDataKey}).starting_time_rate;    %I assign the LFP sampling rate that was already used. Not sure yet if a different value than 1250 Hz will cause problems
+    
+    if sessionInfo.rates.wideband <1250
+        warning 'Something weird will happen. Not thoroughly tested yet'
+    end
+end
+
+
+
+% Get the ElectrodeGroups
+% There is a lot of redundancy on this one
+
+% electrode_description = nwb2.general_extracellular_ephys_electrodes.vectordata.get('electrode_description').data;
+% filtering = nwb2.general_extracellular_ephys_electrodes.vectordata.get('filtering').data;
+% group = nwb2.general_extracellular_ephys_electrodes.vectordata.get('group').data;
+% group_name = nwb2.general_extracellular_ephys_electrodes.vectordata.get('group_name').data;
+% imp = nwb2.general_extracellular_ephys_electrodes.vectordata.get('imp').data.load;
+location = nwb2.general_extracellular_ephys_electrodes.vectordata.get('location').data;
+% shank = nwb2.general_extracellular_ephys_electrodes.vectordata.get('shank').data.load;
+% x = nwb2.general_extracellular_ephys_electrodes.vectordata.get('x').data.load;
+% y = nwb2.general_extracellular_ephys_electrodes.vectordata.get('y').data.load;
+% z = nwb2.general_extracellular_ephys_electrodes.vectordata.get('z').data.load;
+
+
+
+
+
+% nGroups = sum(unique(shank)>0); % -1 doesn't belong to a Shank Group
+nGroups = length(unique(nwb2.general_extracellular_ephys_electrodes.vectordata.get('group_name').data));
+uniqueGroupNames = unique(nwb2.general_extracellular_ephys_electrodes.vectordata.get('group_name').data);
+groupNames = nwb2.general_extracellular_ephys_electrodes.vectordata.get('group_name').data;
+
+
+sessionInfo.spikeGroups.nGroups  = nGroups;
+sessionInfo.spikeGroups.nSamples = ones(1,sessionInfo.spikeGroups.nGroups)*32; % The file I found had 32 here
+
+
+id = nwb2.general_extracellular_ephys_electrodes.vectordata.get('amp_channel').data.load;
+
+
+sessionInfo.spikeGroups.groups = cell(1,sessionInfo.spikeGroups.nGroups);
+for iGroup = 1:sessionInfo.spikeGroups.nGroups
+    sessionInfo.spikeGroups.groups{iGroup} = id(ismember(groupNames, uniqueGroupNames{iGroup}))';
+    
+    % Redundant
+    for iChannel = 1:length(id(ismember(groupNames, uniqueGroupNames{iGroup}))')
+        sessionInfo.ElecGp{1,iGroup}.channel{1,iChannel} = sessionInfo.spikeGroups.groups{iGroup}(iChannel);
+    end
+    
+    % Redundant
+    sessionInfo.SpkGrps(iGroup).Channels   = id(ismember(groupNames, uniqueGroupNames{iGroup}))';
+    sessionInfo.SpkGrps(iGroup).nSamples   = 32;
+    sessionInfo.SpkGrps(iGroup).PeakSample = 16; 
+    sessionInfo.SpkGrps(iGroup).nFeatures  = 3; 
+    
+    
+end
+
+
+% Add Region Info
+for iChannel = 1:sessionInfo.nChannels
+    sessionInfo.region{iChannel} = location{iChannel};
+end
+
+
+
+
+% Get the rest of the Info
+sessionInfo.nBits          = 16; % ASSUMING THAT NWB GIVES INT16 PRECISION
+sessionInfo.rates.video    = 0;
+sessionInfo.FileName       = nwb2.identifier;%%%%%%%%%%%%%%%% no extension - I DON'T USE THE FILENAME OF THE NWB HERE JUST IN CASE SOMEONE CHANGED IT. 
+% sessionInfo.SampleTime     = 50; % 50 no idea
+sessionInfo.nElecGps       = nGroups; % 13
+% sessionInfo.ElecGp         = []; % 1x13 cell (struct with 1x12 cell inside)
+% sessionInfo.HiPassFreq     = ;% probably the one from the LFP conversion
+% sessionInfo.Date           = 
+% sessionInfo.VoltageRange   = % 20
+% sessionInfo.Amplification  = % 1000
+% sessionInfo.Offset         = 0;
+% sessionInfo.AnatGrps       =
+% sessionInfo.spikeGroups.groups        = {1:32};
+% sessionInfo.spikeGroups.nSamples = 1; % I ADDED THIS FOR bz_GetSpikes
+sessionInfo.channels       =  0:sessionInfo.nChannels-1 ;% 1x128 % starts from 0              THIS IS USED IN THE bz_GetLFP in the end to assign channels to regions
+% sessionInfo.lfpChans       =
+% sessionInfo.thetaChans     =
+% sessionInfo.region         = % cell 1x128
+% sessionInfo.depth          = 1;   % 3324 - single value
+% sessionInfo.ca1            = 116; % 116 - single value
+% sessionInfo.ca3            = [] % []
+% sessionInfo.ls             = [];
+% sessionInfo.animal         = 'MONKEY'% string
+% sessionInfo.refChan        = 112; % single value
+
+sessionInfo.useRaw           = RawDataPresent; % I add this to choose which data to convert to .lfp files
+
+
+
+end
+

--- a/NWB/testing_BUZSAKI_NWB_functions_fidelity.m
+++ b/NWB/testing_BUZSAKI_NWB_functions_fidelity.m
@@ -1,0 +1,130 @@
+
+
+%% Test BUZSAKI FUNCTIONS and NWB FUNCTIONS
+
+% For the NWB functions, the nwb file_path should be added as an input
+% (no need to have only one .nwb in the same folder)
+nwb_file = 'C:\Users\McGill\Documents\GitHub\matnwb\Nas\YutaMouse41\YutaMouse41\YutaMouse41.nwb';
+
+
+% If the nwb_file is not specified, the functions will search for a unique
+% .nwb within the current directory
+
+% The current Buzcode functions and the NWB functions are differentiated by
+% the _NWB suffix.
+
+
+% Konstantinos Nasiotis 2019
+
+
+%% GET_LFP
+
+% channel ID 5 (= # 6)
+tic
+lfp = bz_GetLFP(5);
+disp(['Loading a single channel with Buzsaki code takes: ' num2str(toc)])   % 18.0 seconds for a 40369 seconds recording at 1250 Hz
+
+tic
+lfp_NWB = bz_GetLFP_NWB(5, 'nwb_file', nwb_file);
+disp(['Loading a single channel with NWB code takes: ' num2str(toc)])       % 4.3 seconds for a 40369 seconds recording at 1250 Hz
+
+figure(1);plot(lfp.data)
+figure(2);plot(lfp_NWB.data)
+
+
+% channel ID 5 and 10 (= #6 and #11)
+tic
+lfp = bz_GetLFP([5 10]);
+disp(['Loading a single channel with Buzsaki code takes: ' num2str(toc)])   % 18 seconds for a 40369 seconds recording at 1250 Hz
+
+tic
+lfp_NWB = bz_GetLFP_NWB([5 10], 'nwb_file', nwb_file);
+disp(['Loading a single channel with NWB code takes: ' num2str(toc)])       % 4.3 seconds for a 40369 seconds recording at 1250 Hz
+
+figure(1);subplot(1,2,1);plot(lfp.data(:,1)); subplot(1,2,2);plot(lfp.data(:,2))
+figure(2);subplot(1,2,1);plot(lfp_NWB.data(:,1)); subplot(1,2,2);plot(lfp_NWB.data(:,2))
+
+
+
+% channel ID 5 (= # 6), from 0 to 120 seconds
+lfp     = bz_GetLFP(5,'restrict',[0 120]);
+lfp_NWB = bz_GetLFP_NWB(5,'restrict',[0 120]);
+
+figure(1);plot(lfp.data)
+figure(2);plot(lfp_NWB.data)
+
+
+
+% same, plus from 240.2 to 265.23 seconds
+lfp     = bz_GetLFP(5,'restrict',[0 120;240.2 265.23]);
+lfp_NWB = bz_GetLFP_NWB(5, 'restrict',[0 120;240.2 265.23],'nwb_file', nwb_file);
+
+
+figure(1);subplot(1,2,1); plot(lfp(1).data) ; subplot(1,2,2); plot(lfp(2).data)
+figure(2);subplot(1,2,1); plot(lfp_NWB(1).data) ; subplot(1,2,2); plot(lfp_NWB(2).data)
+
+
+
+% Downsample recording
+lfp     = bz_GetLFP    (5, 'restrict',[0 120], 'downsample', 2);
+lfp_NWB = bz_GetLFP_NWB(5, 'restrict',[0 120], 'downsample', 2);
+
+figure(1);plot(lfp.data)
+figure(2);plot(lfp_NWB.data)
+
+
+
+%% GET SPIKES
+
+% Select ALL Neurons
+spikes     = bz_GetSpikes('UID',[2 4 7]);
+spikes_NWB = bz_GetSpikes_NWB('UID',[2 4 7]);
+spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'UID',[2 4 7]);
+
+% Select Neurons: #2, #4, #7
+spikes     = bz_GetSpikes('UID',[2 4 7]);
+spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'UID',[2 4 7]);
+
+% Select Neurons from spikeGroups: #2, #4
+spikes     = bz_GetSpikes('spikeGroups', [2,4]);
+spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'spikeGroups', [2,4]);
+
+% Select Neurons from region: 'unknown'
+spikes     = bz_GetSpikes('region', 'unknown');
+spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'region', 'unknown');
+
+% Loads and saves all spiking data into buzcode format .cellinfo. struct
+spikes = bz_GetSpikes('saveMat',true); 
+spikes_NWB = bz_GetSpikes_NWB('nwb_file', nwb_file, 'saveMat',true);
+
+
+
+%% Load behavior
+
+% Test that it works
+behavior = bz_LoadBehavior;
+behavior = bz_LoadBehavior_NWB;
+behavior = bz_LoadBehavior_NWB('nwb_file', nwb_file);
+behavior = bz_LoadBehavior_NWB('nwb_file', nwb_file, 'EightMazePosition_norm_spatial_series');
+behavior = bz_LoadBehavior_NWB('EightMazePosition_norm_spatial_series');
+
+
+%% Load events
+basePath = 'C:\Users\McGill\Documents\GitHub\matnwb\Nas\YutaMouse41\YutaMouse41';
+events = bz_LoadEvents(basePath, 'YutaMouse41.PulseStim_0V_10021ms_LD0.events');
+
+
+events = bz_LoadEvents_NWB;
+events = bz_LoadEvents_NWB('nwb_file', nwb_file);
+events = bz_LoadEvents_NWB('nwb_file', nwb_file, 'PulseStim_5V_77777ms_LD12');
+events = bz_LoadEvents_NWB('PulseStim_5V_77777ms_LD12');
+
+
+%% bz_firingMap1D
+
+[firingMaps] = bz_firingMap1D(spikes_NWB,behavior,4,'savemat',false);
+% let's look at some ratemaps...
+subplot(3,2,2)
+imagesc(squeeze(firingMaps.rateMaps{1}(96,:,:)))
+ylabel('trial #')
+xlabel('position')


### PR DESCRIPTION
Buzsaki functions converted to work with the NWB file format.

The functions have the same input and produce the same structured outputs.
It is assumed that all the information of a recording has already been converted correctly to a NWB file and the functions get info from the appropriate fields.

Example calls of the functions are at the beginning of each file.

testing_BUZSAKI_NWB_functions_fidelity.m has calls for both existing Buzcode functions and the NWB counterparts that I used for easy comparison.

The functions were tested on this file:
https://drive.google.com/file/d/1ceoaieEpn7NVmU36o-yRTWwJFYjjWdJQ/view



Problem with this dataset:
The .map field in: behavior.events.map takes a long time to compute in this dataset since the trials are long (probably too long) and the default bin_size for the .map is set to 200 - Consider increasing the bin size


