### PR TITLE
Fixed memcpy declaration

### DIFF
--- a/analysis/spikes/correlation/CCGHeart.c
+++ b/analysis/spikes/correlation/CCGHeart.c
@@ -22,7 +22,7 @@
    If you think this program is anal, you're right.  Use the MATLAB wrapper instead.
  */
 
-
+#include <string.h>
 #include "mex.h"
 #include "matrix.h"
 #include <stdlib.h>


### PR DESCRIPTION
When I tried to run the CCG script, I got this error:

```
/Users/rishabjain/Desktop/Research/PETH neuron
test/human-layers/ExternalPackages/dev/analysis/monosynapticPairs/CCGHeart.c:195:3: error: call to
undeclared library function 'memcpy' with type 'void *(void *, const void *, unsigned long)'; ISO C99
and later do not support implicit function declarations [-Wimplicit-function-declaration]
                memcpy(mxGetPr(plhs[1]), (void *)Pairs, PairCnt*sizeof(unsigned int));
                ^
/Users/rishabjain/Desktop/Research/PETH neuron
test/human-layers/ExternalPackages/dev/analysis/monosynapticPairs/CCGHeart.c:195:3: note: include the
header <string.h> or explicitly provide a declaration for 'memcpy'
```

The error message is indicating that the function memcpy is being used without a proper declaration.

I simply added
```
#include <string.h>
```

To this C engine file.