### PR TITLE
includes string.h, required to compile on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Desktop.ini
 $RECYCLE.BIN/
 
 # Compiled source 
+*.mex*
 *.mexa64
 *.mexw64
 *.asv

--- a/analysis/monosynapticPairs/CCGHeart.c
+++ b/analysis/monosynapticPairs/CCGHeart.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
+#include <string.h>
 
 #define CHECK
 #define STRLEN 10000


### PR DESCRIPTION
Adds missing #include <string.h> in CCGHeart.c so memcpy has a proper declaration during compilation on macOS toolchains.